### PR TITLE
Add sonar sensor

### DIFF
--- a/models/rodi/model.sdf
+++ b/models/rodi/model.sdf
@@ -37,6 +37,19 @@
           </mesh>
         </geometry>
       </visual>
+
+      <sensor name="sonar" type="sonar">
+        <pose>0.04 0 0 0 -1.7 0</pose>
+        <sonar>
+          <min>0.2</min>
+          <max>1.0</max>
+          <!-- FIXME: this is an estimated value -->
+          <radius>0.5</radius>
+        </sonar>
+        <always_on>1</always_on>
+        <update_rate>30</update_rate>
+        <visualize>true</visualize>
+      </sensor>
     </link>
 
     <joint type="fixed" name="ball_caster_joint">


### PR DESCRIPTION
@garyservin, can you please test if these patches also work on your setup (was only tested in Gazebo 6.5.1) and accept the pull request if that's the case.

I've found the cause of the corrupted data in the HTTP response issue that we faced. This was fixed in commit https://github.com/rodibot/rodi_gazebo/commit/2fd9443062d49fe2eecb66f7f3fa328f3a0206a2 ("plugins: Fix libmicrohttpd create response memory mode used").

The first patch adds the sonar to the RoDI sdf model and the second patch implements the See command in the plugin.